### PR TITLE
Enables support for Laravel 5.7, matches system environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Create CloudFront signed URLs in Laravel 5.5+
-Easy to use Laravel 5.5+ wrapper around the official AWS PHP SDK which allows to sign URLs to access Private Content through CloudFront CDN
+# Create CloudFront signed URLs in Laravel 5.6+
+Easy to use Laravel 5.6+ wrapper around the official AWS PHP SDK which allows to sign URLs to access Private Content through CloudFront CDN
 
 Inspired by [laravel-url-signer](https://github.com/spatie/laravel-url-signer)
 
@@ -48,23 +48,23 @@ return [
     /*
      * The private key used to sign all URLs.
      */
-    'private_key_path' => storage_path(env('AWS_CLOUDFRONT_PRIVATE_KEY_PATH', 'trusted-signer.pem')),
+    'private_key_path' => storage_path(env('CLOUDFRONT_PRIVATE_KEY_PATH', 'trusted-signer.pem')),
 
     /*
      * Identifies the CloudFront key pair associated
      * to the trusted signer which validates signed URLs.
      */
-    'key_pair_id' => env('AWS_CLOUDFRONT_KEY_PAIR_ID', ''),
+    'key_pair_id' => env('CLOUDFRONT_KEY_PAIR_ID', ''),
 
     /*
      * AWS region to connect to.
      */
-    'region' => env('AWS_DEFAULT_REGION', 'us-west-2'),
+    'region' => env('DEFAULT_REGION', 'us-west-2'),
 
     /*
      * CloudFront API version, by default it uses the latest available.
      */
-    'version' => env('AWS_CLOUDFRONT_API_VERSION', 'latest'),
+    'version' => env('CLOUDFRONT_API_VERSION', 'latest'),
 
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ return [
     /*
      * The private key used to sign all URLs.
      */
-    'private_key_path' => storage_path(env('CLOUDFRONT_PRIVATE_KEY_PATH', 'trusted-signer.pem')),
+    'private_key_path' => storage_path(env('AWS_CLOUDFRONT_PRIVATE_KEY_PATH', 'trusted-signer.pem')),
 
     /*
      * Identifies the CloudFront key pair associated
      * to the trusted signer which validates signed URLs.
      */
-    'key_pair_id' => env('CLOUDFRONT_KEY_PAIR_ID', ''),
+    'key_pair_id' => env('AWS_CLOUDFRONT_KEY_PAIR_ID', ''),
 
     /*
      * AWS region to connect to.
@@ -64,8 +64,8 @@ return [
     /*
      * CloudFront API version, by default it uses the latest available.
      */
-    'version' => env('CLOUDFRONT_API_VERSION', 'latest'),
-    
+    'version' => env('AWS_CLOUDFRONT_API_VERSION', 'latest'),
+
 ];
 ```
 ## Usage

--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ return [
     'key_pair_id' => env('CLOUDFRONT_KEY_PAIR_ID', ''),
 
     /*
-     * AWS region to connect to.
-     */
-    'region' => env('DEFAULT_REGION', 'us-west-2'),
-
-    /*
      * CloudFront API version, by default it uses the latest available.
      */
     'version' => env('CLOUDFRONT_API_VERSION', 'latest'),

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php" : "^7.1",
-        "illuminate/support": "~5.5.0|~5.6.0",
+        "illuminate/support": "~5.5",
         "aws/aws-sdk-php": "^3.52"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         }
     ],
     "require": {
-        "php" : "^7.1",
-        "illuminate/support": "~5.5",
+        "php" : "^7.1.3",
+        "illuminate/support": "~5.6.0|~5.7.0",
         "aws/aws-sdk-php": "^3.52"
     },
     "require-dev": {

--- a/config/cloudfront-url-signer.php
+++ b/config/cloudfront-url-signer.php
@@ -9,17 +9,17 @@ return [
     /*
      * The private key used to sign all URLs.
      */
-    'private_key_path' => storage_path(env('CLOUDFRONT_PRIVATE_KEY_PATH', 'trusted-signer.pem')),
+    'private_key_path' => storage_path(env('AWS_CLOUDFRONT_PRIVATE_KEY_PATH', 'trusted-signer.pem')),
 
     /*
      * Identifies the CloudFront key pair associated
      * to the trusted signer which validates signed URLs.
      */
-    'key_pair_id' => env('CLOUDFRONT_KEY_PAIR_ID', ''),
+    'key_pair_id' => env('AWS_CLOUDFRONT_KEY_PAIR_ID', ''),
 
     /*
      * CloudFront API version, by default it uses the latest available.
      */
-    'version' => env('CLOUDFRONT_API_VERSION', 'latest'),
+    'version' => env('AWS_CLOUDFRONT_API_VERSION', 'latest'),
 
 ];

--- a/config/cloudfront-url-signer.php
+++ b/config/cloudfront-url-signer.php
@@ -9,17 +9,17 @@ return [
     /*
      * The private key used to sign all URLs.
      */
-    'private_key_path' => storage_path(env('AWS_CLOUDFRONT_PRIVATE_KEY_PATH', 'trusted-signer.pem')),
+    'private_key_path' => storage_path(env('CLOUDFRONT_PRIVATE_KEY_PATH', 'trusted-signer.pem')),
 
     /*
      * Identifies the CloudFront key pair associated
      * to the trusted signer which validates signed URLs.
      */
-    'key_pair_id' => env('AWS_CLOUDFRONT_KEY_PAIR_ID', ''),
+    'key_pair_id' => env('CLOUDFRONT_KEY_PAIR_ID', ''),
 
     /*
      * CloudFront API version, by default it uses the latest available.
      */
-    'version' => env('AWS_CLOUDFRONT_API_VERSION', 'latest'),
+    'version' => env('CLOUDFRONT_API_VERSION', 'latest'),
 
 ];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory>./tests/</directory>


### PR DESCRIPTION
- Removes version constraint to enable installation on Laravel 5.7
- Adds "AWS" prefix to environment variables (matches Laravel variables for S3)
- Removes deprecated syntaxCheck attribute from PHPUnit configuration file