### PR TITLE
Support for Laravel 6+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php" : "^7.1.3",
-        "illuminate/support": "~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/support": "^5.6|^6.0",
         "aws/aws-sdk-php": "^3.52"
     },
     "require-dev": {


### PR DESCRIPTION
Hi!

Thanks for this package. I forked it myself to update support for Laravel 6+ and it's working well.

This PR adds support for any Laravel version above 5.6